### PR TITLE
Add missing comma characters in database schema file

### DIFF
--- a/sql/WSStats.mysql
+++ b/sql/WSStats.mysql
@@ -2,7 +2,7 @@ CREATE TABLE /*_*/WSPS (
   `id` int(11) NOT NULL PRIMARY KEY auto_increment,
   `page_id` int(11) NOT NULL default '0',
   `user_id` int(11) NOT NULL default '0',
-  `added` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
-  `title` varchar(250) NOT NULL DEFAULT ''
+  `added` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `title` varchar(250) NOT NULL DEFAULT '',
   `isSpecialPage` INT(1) NOT NULL DEFAULT '0'
 ) /*$wgDBTableOptions*/;


### PR DESCRIPTION
The installation fails due to missing comma characters in the database schema file.